### PR TITLE
Fixing - Root resolver for query type 'Query' not found!

### DIFF
--- a/src/main/java/com/howtographql/hackernews/Query.java
+++ b/src/main/java/com/howtographql/hackernews/Query.java
@@ -1,13 +1,13 @@
 package com.howtographql.hackernews;
 
-import com.coxautodev.graphql.tools.GraphQLRootResolver;
+import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 
 import java.util.List;
 
 /**
  * Query root. Contains top-level queries.
  */
-class Query implements GraphQLRootResolver {
+class Query implements GraphQLQueryResolver {
 
     private final LinkRepository linkRepository;
 


### PR DESCRIPTION
Not working as per steps provided till https://www.howtographql.com/graphql-java/2-queries/. 

[WARNING] /graphql
javax.servlet.ServletException: javax.servlet.ServletException: com.coxautodev.graphql.tools.SchemaClassScannerError: Root resolver for query type 'Query' not found!
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:146)

Caused by: javax.servlet.ServletException: com.coxautodev.graphql.tools.SchemaClassScannerError: Root resolver for query type 'Query' not found!
	at org.eclipse.jetty.servlet.ServletContextHandler$Context.createServlet(ServletContextHandler.java:1332)
	at org.eclipse.jetty.servlet.ServletHolder.newInstance(ServletHolder.java:1273)